### PR TITLE
feat: add type utilities

### DIFF
--- a/test/event-abort.test.ts
+++ b/test/event-abort.test.ts
@@ -1,4 +1,4 @@
-import { Emitter } from '../src'
+import { Emitter, InferListenerType } from '../src'
 
 it('(on) supports aborting a listener by calling `abort()` on its controller', () => {
   const listener = vi.fn()


### PR DESCRIPTION
Makes it easier to extract different types from the emitter, respecting its `EventMap`. Also refactors the internal types to be cleaner. 