### PR TITLE
fix: emit "removeListener" hook on `.removeAllListeners()`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -444,13 +444,14 @@ export class Emitter<EventMap extends DefaultEventMap> {
       EventType,
       WithReservedEvents<EventMap>
     >,
-  ): void {
-    this.#listeners.delete(type, listener)
+  ): boolean {
+    const removed = this.#listeners.delete(type, listener)
     const cleanup = this.#listenerAbortCleanups.get(listener)
     if (cleanup) {
       cleanup()
       this.#listenerAbortCleanups.delete(listener)
     }
+    return removed
   }
 
   /**
@@ -671,7 +672,9 @@ export class Emitter<EventMap extends DefaultEventMap> {
   ): void {
     const options = this.#listenerOptions.get(listener)
 
-    this.#deleteListener(type, listener)
+    if (!this.#deleteListener(type, listener)) {
+      return
+    }
 
     for (const hook of this.#hookListeners.get('removeListener')) {
       hook(
@@ -825,10 +828,11 @@ export class Emitter<EventMap extends DefaultEventMap> {
 
     if (options?.once) {
       const type = this.#isTypelessListener(listener) ? '*' : event.type
-      this.#deleteListener(type, listener)
 
-      for (const hook of this.#hookListeners.get('removeListener')) {
-        hook(type, listener, options)
+      if (this.#deleteListener(type, listener)) {
+        for (const hook of this.#hookListeners.get('removeListener')) {
+          hook(type, listener, options)
+        }
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -655,7 +655,14 @@ export class Emitter<EventMap extends DefaultEventMap> {
     EventType extends keyof WithReservedEvents<EventMap> & string,
   >(type?: EventType): void {
     if (type == null) {
-      this.#listeners.clear()
+      for (const [listenerType, listeners] of this.#listeners.entries()) {
+        while (listeners.length > 0) {
+          this.removeListener(
+            listenerType as keyof WithReservedEvents<EventMap> & string,
+            listeners[0],
+          )
+        }
+      }
 
       for (const [hookType, hookListener] of this.#hookListeners) {
         if (!this.#hookListenerOptions.get(hookListener)?.persist) {
@@ -669,7 +676,11 @@ export class Emitter<EventMap extends DefaultEventMap> {
       return
     }
 
-    this.#listeners.deleteAll(type)
+    const listeners = this.listeners(type)
+
+    while (listeners.length > 0) {
+      this.removeListener(type, listeners[0])
+    }
   }
 
   /**

--- a/src/lens-list.ts
+++ b/src/lens-list.ts
@@ -56,24 +56,29 @@ export class LensList<ValueMap extends Record<string, any>> {
 
   /**
    * Delete the value belonging to the given key.
+   * Returns `true` if the value was present and removed, `false` otherwise.
    */
   public delete<K extends keyof ValueMap & string>(
     key: K,
     value: ValueMap[K],
-  ): void {
+  ): boolean {
     if (this.size === 0) {
-      return
+      return false
     }
-
-    this.#list = this.#list.filter((item) => item[1] !== value)
 
     const values = this.#lens.get(key)
-    if (values) {
-      const index = values.indexOf(value)
-      if (index !== -1) {
-        values.splice(index, 1)
-      }
+    if (!values) {
+      return false
     }
+
+    const index = values.indexOf(value)
+    if (index === -1) {
+      return false
+    }
+
+    values.splice(index, 1)
+    this.#list = this.#list.filter((item) => item[1] !== value)
+    return true
   }
 
   /**

--- a/test/hooks/remove-listener.test.ts
+++ b/test/hooks/remove-listener.test.ts
@@ -92,8 +92,8 @@ it('calls multiple hooks', () => {
   emitter.on('hello', listener)
   emitter.removeListener('hello', listener)
 
-  expect(hookOne).toHaveBeenCalledOnce()
-  expect(hookTwo).toHaveBeenCalledOnce()
+  expect(hookOne).toHaveBeenCalledExactlyOnceWith('hello', listener, undefined)
+  expect(hookTwo).toHaveBeenCalledExactlyOnceWith('hello', listener, undefined)
 })
 
 it('calls the hook when a wildcard listener is removed', () => {
@@ -186,5 +186,39 @@ it('persists the hook through emitter.removeAllListeners() if persist is true', 
   emitter.on('hello', listener)
   emitter.removeListener('hello', listener)
 
-  expect(hook).toHaveBeenCalledOnce()
+  expect(hook).toHaveBeenCalledExactlyOnceWith('hello', listener, undefined)
+})
+
+it('calls the hook when removing all listeners of a given type', () => {
+  const emitter = new Emitter<{ hello: TypedEvent }>()
+  const hook = vi.fn()
+  emitter.hooks.on('removeListener', hook)
+
+  const listenerOne = vi.fn()
+  emitter.on('hello', listenerOne)
+  const listenerTwo = vi.fn()
+  emitter.on('hello', listenerTwo)
+
+  emitter.removeAllListeners('hello')
+
+  expect.soft(hook).toHaveBeenCalledTimes(2)
+  expect.soft(hook).toHaveBeenNthCalledWith(1, 'hello', listenerOne, undefined)
+  expect.soft(hook).toHaveBeenNthCalledWith(2, 'hello', listenerTwo, undefined)
+})
+
+it('calls the hook when removing all listeners', () => {
+  const emitter = new Emitter<{ hello: TypedEvent }>()
+  const hook = vi.fn()
+  emitter.hooks.on('removeListener', hook)
+
+  const listenerOne = vi.fn()
+  emitter.on('hello', listenerOne)
+  const listenerTwo = vi.fn()
+  emitter.on('hello', listenerTwo)
+
+  emitter.removeAllListeners()
+
+  expect.soft(hook).toHaveBeenCalledTimes(2)
+  expect.soft(hook).toHaveBeenNthCalledWith(1, 'hello', listenerOne, undefined)
+  expect.soft(hook).toHaveBeenNthCalledWith(2, 'hello', listenerTwo, undefined)
 })

--- a/test/hooks/remove-listener.test.ts
+++ b/test/hooks/remove-listener.test.ts
@@ -128,6 +128,41 @@ it('fires the hook after the listener is removed', () => {
   expect(listenerCounts).toEqual([1, 0])
 })
 
+it('does not call the hook when removing a listener that was never registered', () => {
+  const emitter = new Emitter<{ hello: TypedEvent }>()
+  const hook = vi.fn()
+  emitter.hooks.on('removeListener', hook)
+
+  emitter.removeListener('hello', vi.fn())
+
+  expect(hook).not.toHaveBeenCalled()
+})
+
+it('does not re-fire the hook when the same listener is removed twice', () => {
+  const emitter = new Emitter<{ hello: TypedEvent }>()
+  const hook = vi.fn()
+  emitter.hooks.on('removeListener', hook)
+
+  const listener = vi.fn()
+  emitter.on('hello', listener)
+  emitter.removeListener('hello', listener)
+  emitter.removeListener('hello', listener)
+
+  expect(hook).toHaveBeenCalledOnce()
+})
+
+it('does not call the hook when removing a listener registered for another type', () => {
+  const emitter = new Emitter<{ hello: TypedEvent; goodbye: TypedEvent }>()
+  const hook = vi.fn()
+  emitter.hooks.on('removeListener', hook)
+
+  const listener = vi.fn()
+  emitter.on('hello', listener)
+  emitter.removeListener('goodbye', listener)
+
+  expect(hook).not.toHaveBeenCalled()
+})
+
 it('removes the hook via hooks.removeListener()', () => {
   const emitter = new Emitter<{ hello: TypedEvent }>()
   const hook = vi.fn()


### PR DESCRIPTION
The `removeListener` hook isn't being called on `.removeAllListeners()`, which makes it less predictable. 