### PR TITLE
fix: avoid MessageEvent inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm install rettime
 
 ### `TypedEvent`
 
-`TypedEvent` is a subset of `MessageEvent` that allows for type-safe event declaration.
+`TypedEvent` is a small event class that allows for type-safe event declaration without relying on DOM event inheritance.
 
 ```ts
 new TypedEvent<DataType, ReturnType, EventType>(type: EventType, { data: DataType })
@@ -100,7 +100,6 @@ const emitter = new Emitter<{ greeting: GreetingEvent<'john'> }>()
 emitter.on('greeting', (event) => {
   console.log(event instanceof GreetingEvent) // true
   console.log(event instanceof TypedEvent) // true
-  console.log(event instanceof MessageEvent) // true
 
   console.log(event.type) // "greeting"
   console.log(event.data) // "john"
@@ -183,7 +182,7 @@ import { Emitter, TypedEvent } from 'rettime'
 const emitter = new Emitter<{ hello: TypedEvent<string> }>()
 
 emitter.on('hello', (event) => {
-  // `event` is a `TypedEvent` instance derived from `MessageEvent`.
+  // `event` is a `TypedEvent` instance.
   console.log(event.data)
 })
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,14 +15,6 @@ type IsReservedEvent<Type extends string> = Type extends keyof ReservedEventMap
   ? true
   : false
 
-export interface TypedEvent<
-  DataType = void,
-  ReturnType = void,
-  EventType extends string = string,
-> extends Omit<MessageEvent<DataType>, 'type'> {
-  type: EventType
-}
-
 const kDefaultPrevented = Symbol('kDefaultPrevented')
 const kPropagationStopped = Symbol('kPropagationStopped')
 const kImmediatePropagationStopped = Symbol('kImmediatePropagationStopped')
@@ -31,10 +23,7 @@ export class TypedEvent<
   DataType = void,
   ReturnType = void,
   EventType extends string = string,
->
-  extends MessageEvent<DataType>
-  implements TypedEvent<DataType, ReturnType, EventType>
-{
+> {
   /**
    * @note Keep a placeholder property with the return type
    * because the type must be set somewhere in order to be
@@ -46,12 +35,17 @@ export class TypedEvent<
   [kPropagationStopped]?: Emitter<any>;
   [kImmediatePropagationStopped]?: boolean
 
+  public readonly data: DataType
+  public readonly type: EventType
+
   constructor(
     ...args: [DataType] extends [void]
       ? [type: EventType]
       : [type: EventType, init: { data: DataType }]
   ) {
-    super(args[0], args[1])
+    const [type, init] = args
+    this.type = type
+    this.data = init?.data as DataType
     this[kDefaultPrevented] = false
   }
 
@@ -60,17 +54,15 @@ export class TypedEvent<
   }
 
   public preventDefault(): void {
-    super.preventDefault()
     this[kDefaultPrevented] = true
   }
 
   public stopImmediatePropagation(): void {
-    /**
-     * @note Despite `.stopPropagation()` and `.stopImmediatePropagation()` being defined
-     * in Node.js, they do nothing. It is safe to re-define them.
-     */
-    super.stopImmediatePropagation()
     this[kImmediatePropagationStopped] = true
+  }
+
+  public stopPropagation(): void {
+    // Propagation state is managed by the emitting `Emitter` instance.
   }
 }
 
@@ -835,7 +827,7 @@ export class Emitter<EventMap extends DefaultEventMap> {
     }
   }
 
-  #callListener(event: Event, listener: (event: any) => any) {
+  #callListener(event: TypedEvent, listener: (event: any) => any) {
     for (const hook of this.#hookListeners.get('beforeEmit').slice()) {
       if (hook(event as EventMap[keyof EventMap & string]) === false) {
         return

--- a/test/emit-as-promise.test.ts
+++ b/test/emit-as-promise.test.ts
@@ -35,7 +35,9 @@ it('rejects if one of the listeners throws', async () => {
 
 it('stops calling listeners if immediate propagation is stopped', async () => {
   const emitter = new Emitter<{ hello: TypedEvent }>()
-  const listenerOne = vi.fn((event: Event) => event.stopImmediatePropagation())
+  const listenerOne = vi.fn((event: TypedEvent) =>
+    event.stopImmediatePropagation(),
+  )
   const listenerTwo = vi.fn()
   emitter.on('hello', listenerOne)
   emitter.on('hello', listenerTwo)
@@ -47,8 +49,12 @@ it('stops calling listeners if immediate propagation is stopped', async () => {
 })
 
 it('stops calling listeners if propagation is stopped', async () => {
-  const emitterOne = new Emitter<{ greet: TypedEvent<string, Event> }>()
-  const emitterTwo = new Emitter<{ greet: TypedEvent<string, Event> }>()
+  const emitterOne = new Emitter<{
+    greet: TypedEvent<string, unknown>
+  }>()
+  const emitterTwo = new Emitter<{
+    greet: TypedEvent<string, unknown>
+  }>()
 
   emitterOne.on('greet', (event) => event)
   emitterOne.on('greet', (event) => {
@@ -62,8 +68,8 @@ it('stops calling listeners if propagation is stopped', async () => {
   const event = new TypedEvent('greet', { data: 'hello' })
 
   await expect(emitterOne.emitAsPromise(event)).resolves.toEqual([
-    expect.any(Event),
-    expect.any(Event),
+    expect.any(TypedEvent),
+    expect.any(TypedEvent),
   ])
   await expect(emitterTwo.emitAsPromise(event)).resolves.toEqual([])
 })

--- a/test/typed-event.test.ts
+++ b/test/typed-event.test.ts
@@ -1,0 +1,28 @@
+import { TypedEvent } from '#src/index.js'
+
+it('does not depend on global MessageEvent', () => {
+  const original = globalThis.MessageEvent
+
+  globalThis.MessageEvent = undefined
+
+  try {
+    const event = new TypedEvent('hello', { data: 'world' })
+
+    expect(event.type).toBe('hello')
+    expect(event.data).toBe('world')
+  } finally {
+    globalThis.MessageEvent = original
+  }
+})
+
+it('tracks default and propagation state without DOM inheritance', () => {
+  const event = new TypedEvent('hello')
+
+  expect(event.defaultPrevented).toBe(false)
+
+  event.preventDefault()
+  event.stopImmediatePropagation()
+  event.stopPropagation()
+
+  expect(event.defaultPrevented).toBe(true)
+})


### PR DESCRIPTION
## Summary

Make `TypedEvent` independent of DOM `MessageEvent` inheritance.

## Motivation

`TypedEvent` currently extends `MessageEvent`, which makes importing `rettime` fail in runtimes where `MessageEvent` is not defined, such as React Native. The emitter only needs a small structural event object with `type`, `data`, and propagation/default methods.

## Changes

- Removed `MessageEvent` inheritance from `TypedEvent`
- Kept `type`, `data`, `defaultPrevented`, `preventDefault`, `stopPropagation`, and `stopImmediatePropagation`
- Updated propagation tests to assert `TypedEvent` return values instead of DOM `Event`
- Added coverage for constructing `TypedEvent` when `globalThis.MessageEvent` is undefined

## Testing

- `pnpm test` — 43 files passed, 240 tests passed
- `pnpm build`
- `pnpm lint`
- `node --input-type=module -e "globalThis.MessageEvent = undefined; const { TypedEvent, Emitter } = await import('rettime'); const emitter = new Emitter(); const event = new TypedEvent('hello', { data: 'world' }); console.log(JSON.stringify({ data: event.data, defaultPrevented: event.defaultPrevented, emitted: emitter.emit(event), type: event.type }))"`